### PR TITLE
Security fix for Prototype Pollution vulnerability

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -141,6 +141,8 @@ export default class Bouillion {
 
       if (_store == undefined) throw new Error('Creation of only 1 new key per set operation is supported');
 
+      if (_store === Object.prototype) throw new Error('Setting property to object prototype is not allowed');
+
       _store[last] = value;
 
     }


### PR DESCRIPTION
### :bar_chart: Metadata *

`bouillon` is vulnerable to `Prototype Pollution`.

#### Bounty URL: https://www.huntr.dev/bounties/1-npm-bouillon

### :gear: Description *

Prototype Pollution refers to the ability to inject properties into existing JavaScript language construct prototypes, such as objects.
JavaScript allows all Object attributes to be altered, including their magical attributes such as `__proto__`, `constructor` and `prototype`. An attacker manipulates these attributes to overwrite, or pollute, a JavaScript application object prototype of the base object by injecting other values. Properties on the Object.prototype are then inherited by all the JavaScript objects through the prototype chain.

### :computer: Technical Description *

Fix implemented by not allowing to modify object prototype.

### :bug: Proof of Concept (PoC) *

1. Create the following PoC file:
```JavaScript
// poc.js
const Bouillon = require('bouillon')

console.log('Before:', {}.polluted)
const bouillon = new Bouillon()
bouillon.set('__proto__.polluted', true)
console.log('After:', {}.polluted)
```
2. Execute the following commands in terminal:
```bash
npm i bouillon # Install vulnerable package
node poc.js #  Run the PoC
```
3. Check the Output:
```
Before : undefined
After : true
```

### :fire: Proof of Fix (PoF) *

![image](https://user-images.githubusercontent.com/43996156/115154848-916a4280-a09a-11eb-91bc-65edf685a8fd.png)

### +1 User Acceptance Testing (UAT)

* I've executed unit tests.
* After fix the functionality is unaffected.
